### PR TITLE
Change the strategy for detecting TroopJS version

### DIFF
--- a/weave.js
+++ b/weave.js
@@ -114,8 +114,8 @@ define([
 					// Create widget instance
 					widget = Widget.apply(Widget, widget_args);
 
-					// TroopJS <= 1.x
-					if (widget.trigger) {
+					// TroopJS <= 1.x (detect presence of ComposeJS)
+					if (widget.constructor._getBases) {
 						// Let `$deferred` be `$.Deferred()`
 						$deferred = $.Deferred();
 


### PR DESCRIPTION
Change the strategy for detecting TroopJS version from ducktyping the `trrigger` method to ducktyping `constructor._getBases`. TroopJS 1.x was using ComposeJS for object composition whereas >=2.x uses troopjs-compose (or some varriant of it).

closes troopjs/troopjs-widget#23